### PR TITLE
Remove multi_target_tracking dependency

### DIFF
--- a/AirSim/ros/src/image_covering_coordination/CMakeLists.txt
+++ b/AirSim/ros/src/image_covering_coordination/CMakeLists.txt
@@ -61,7 +61,6 @@ find_package(catkin REQUIRED COMPONENTS
   tf2_ros
   tf2_sensor_msgs
   airsim_ros_pkgs
-  multi_target_tracking
 )
 
 ## System dependencies are found with CMake's conventions


### PR DESCRIPTION
Removed 'multi_target_tracking' from the list of dependencies so ROS package can compile